### PR TITLE
Raven 3690

### DIFF
--- a/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
+++ b/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
@@ -43,12 +43,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RavenDB.Client.3.0.3599\lib\net45\Raven.Abstractions.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RavenDB.Client.3.0.3599\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
+++ b/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
@@ -44,10 +44,12 @@
   <ItemGroup>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver.Common/packages.config
+++ b/RavenLinqpadDriver.Common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="3.0.3599" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.3690" targetFramework="net45" />
 </packages>

--- a/RavenLinqpadDriver.Package/RavenLinqpadDriver.Package.csproj
+++ b/RavenLinqpadDriver.Package/RavenLinqpadDriver.Package.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Reference Include="Ionic.Zip, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver.Package/RavenLinqpadDriver.Package.csproj
+++ b/RavenLinqpadDriver.Package/RavenLinqpadDriver.Package.csproj
@@ -36,9 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ionic.Zip, Version=1.9.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\DotNetZip.1.9.2\lib\net20\Ionic.Zip.dll</HintPath>
+    <Reference Include="Ionic.Zip, Version=1.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.9.3\lib\net20\Ionic.Zip.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/RavenLinqpadDriver.Package/packages.config
+++ b/RavenLinqpadDriver.Package/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.9.2" targetFramework="net40" />
+  <package id="DotNetZip" version="1.9.3" targetFramework="net40" />
 </packages>

--- a/RavenLinqpadDriver/RavenContext.cs
+++ b/RavenLinqpadDriver/RavenContext.cs
@@ -96,15 +96,15 @@ Total Size: {8:n0}",
             var assemblies = conn.AssemblyPaths.Select(Path.GetFileNameWithoutExtension).Select(Assembly.Load);
 
             var docStoreCreatorType = (from a in assemblies
-                from t in a.TypesImplementing<ICreateDocumentStore>()
-                let hasDefaultCtor = t.GetConstructor(Type.EmptyTypes) != null
-                where !t.IsAbstract && hasDefaultCtor
-                select t).FirstOrDefault();
+                                       from t in a.TypesImplementing<ICreateDocumentStore>()
+                                       let hasDefaultCtor = t.GetConstructor(Type.EmptyTypes) != null
+                                       where !t.IsAbstract && hasDefaultCtor
+                                       select t).FirstOrDefault();
 
-            if (docStoreCreatorType == null) 
+            if (docStoreCreatorType == null)
                 return conn.CreateDocStore();
 
-            var docStoreCreator = (ICreateDocumentStore) Activator.CreateInstance(docStoreCreatorType);
+            var docStoreCreator = (ICreateDocumentStore)Activator.CreateInstance(docStoreCreatorType);
 
             var connectionInfo = new ConnectionInfo
             {
@@ -177,6 +177,12 @@ Total Size: {8:n0}",
         {
             return _docStore.OpenAsyncSession(database);
         }
+
+        public IAsyncDocumentSession OpenAsyncSession(OpenSessionOptions sessionOptions)
+        {
+            return _docStore.OpenAsyncSession(sessionOptions);
+        }
+
 
         public IDocumentSession OpenSession()
         {
@@ -422,6 +428,16 @@ Total Size: {8:n0}",
         public ISyncAdvancedSessionOperation Advanced
         {
             get { return _lazySession.Value.Advanced; }
+        }
+
+        public void SideBySideExecuteIndex(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            _docStore.SideBySideExecuteIndex(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
+        }
+
+        public Task SideBySideExecuteIndexAsync(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            return _docStore.SideBySideExecuteIndexAsync(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
         }
     }
 }

--- a/RavenLinqpadDriver/RavenLinqpadDriver.csproj
+++ b/RavenLinqpadDriver/RavenLinqpadDriver.csproj
@@ -54,10 +54,12 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver/RavenLinqpadDriver.csproj
+++ b/RavenLinqpadDriver/RavenLinqpadDriver.csproj
@@ -53,12 +53,12 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RavenDB.Client.3.0.3599\lib\net45\Raven.Abstractions.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RavenDB.Client.3.0.3599\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/RavenLinqpadDriver/packages.config
+++ b/RavenLinqpadDriver/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="3.0.3599" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.3690" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated the supported RavenDB Client version to 3.0.3690. Also updated
to latest version of DotNetZip. Resolves issue reported in #15.