### PR TITLE
Updated RavenDBLinqpadDriver to work with server version 3 and latest RavenDB libraries

### DIFF
--- a/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
+++ b/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
@@ -43,13 +43,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
+++ b/RavenLinqpadDriver.Common/RavenLinqpadDriver.Common.csproj
@@ -44,10 +44,12 @@
   <ItemGroup>
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver.Common/packages.config
+++ b/RavenLinqpadDriver.Common/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="3.0.3690" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
 </packages>

--- a/RavenLinqpadDriver.sln
+++ b/RavenLinqpadDriver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RavenLinqpadDriver", "RavenLinqpadDriver\RavenLinqpadDriver.csproj", "{FAA16900-38B9-4891-86C3-F595DA1FA6F7}"
 EndProject

--- a/RavenLinqpadDriver/AssemblyVersion.cs
+++ b/RavenLinqpadDriver/AssemblyVersion.cs
@@ -9,5 +9,5 @@
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 using System.Reflection;
-[assembly: AssemblyVersion("0.7.3690.0")]
-[assembly: AssemblyFileVersion("0.7.3690.0")]
+[assembly: AssemblyVersion("0.7.3690.1")]
+[assembly: AssemblyFileVersion("0.7.3690.1")]

--- a/RavenLinqpadDriver/RavenConnectionDialogViewModel.cs
+++ b/RavenLinqpadDriver/RavenConnectionDialogViewModel.cs
@@ -12,9 +12,11 @@ using LINQPad.Extensibility.DataContext;
 using Microsoft.Win32;
 using Raven.Client.Document;
 using Raven.Imports.Newtonsoft.Json;
+using System.Runtime.Serialization;
 
 namespace RavenLinqpadDriver
 {
+    [DataContract]
     public class RavenConnectionDialogViewModel : ViewModelBase
     {
         public const string RavenConnectionInfoKey = "RavenConnectionInfo";
@@ -56,13 +58,12 @@ namespace RavenLinqpadDriver
             return !string.IsNullOrWhiteSpace(SelectedAssemblyPath);
         }
 
-        [JsonIgnore]
         public IConnectionInfo CxInfo { get; set; }
 
-        [JsonIgnore]
         public RelayCommand SaveCommand { get; set; }
 
         [Required]
+        [DataMember]
         public string Name
         {
             get { return _name; }
@@ -82,6 +83,7 @@ namespace RavenLinqpadDriver
         }
 
         [Required]
+        [DataMember]
         public string Url
         {
             get { return _url; }
@@ -100,6 +102,7 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public string DefaultDatabase
         {
             get { return _defaultDatabase; }
@@ -116,6 +119,7 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public string ApiKey
         {
             get { return _apiKey; }
@@ -131,6 +135,7 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public Guid? ResourceManagerId
         {
             get { return _resourceManagerId; }
@@ -148,6 +153,7 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public string Username
         {
             get { return _username; }
@@ -165,6 +171,7 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public string Password
         {
             get { return _password; }
@@ -180,8 +187,10 @@ namespace RavenLinqpadDriver
             }
         }
 
+        [DataMember]
         public BindingList<string> AssemblyPaths { get; set; }
 
+        [DataMember]
         public string Namespaces
         {
             get { return _namespaces; }
@@ -199,10 +208,8 @@ namespace RavenLinqpadDriver
             }
         }
 
-        [JsonIgnore]
         public RelayCommand BrowseAssembliesCommand { get; set; }
 
-        [JsonIgnore]
         public RelayCommand RemoveAssemblyCommand { get; set; }
 
         public void Save()
@@ -213,8 +220,22 @@ namespace RavenLinqpadDriver
             if (!string.IsNullOrWhiteSpace(Password))
                 Password = CxInfo.Encrypt(Password);
 
-            var json = JsonConvert.SerializeObject(this);
-            CxInfo.DriverData.SetElementValue(RavenConnectionInfoKey, json);
+            try
+            {
+                var json = JsonConvert.SerializeObject(this);
+                CxInfo.DriverData.SetElementValue(RavenConnectionInfoKey, json);
+            }
+            catch (Exception ex)
+            {
+                // mvvm.... screw it again
+                MessageBox.Show(string.Format(
+                    "Exception serializing JSON: {0}{1}",
+                    Environment.NewLine,
+                    ex.Message));
+
+                // we don't want linqpad to continue if this happens so throw the exception
+                throw;
+            }
 
             Password = pw;
         }

--- a/RavenLinqpadDriver/RavenContext.cs
+++ b/RavenLinqpadDriver/RavenContext.cs
@@ -209,6 +209,36 @@ Total Size: {8:n0}",
             return _docStore.ExecuteIndexAsync(indexCreationTask);
         }
 
+        public void ExecuteIndexes(List<AbstractIndexCreationTask> indexCreationTasks)
+        {
+            _docStore.ExecuteIndexes(indexCreationTasks);
+        }
+
+        public Task ExecuteIndexesAsync(List<AbstractIndexCreationTask> indexCreationTasks)
+        {
+            return _docStore.ExecuteIndexesAsync(indexCreationTasks);
+        }
+
+        public void SideBySideExecuteIndex(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            _docStore.SideBySideExecuteIndex(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
+        }
+
+        public Task SideBySideExecuteIndexAsync(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            return _docStore.SideBySideExecuteIndexAsync(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
+        }
+
+        public void SideBySideExecuteIndexes(List<AbstractIndexCreationTask> indexCreationTasks, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            _docStore.SideBySideExecuteIndexes(indexCreationTasks, minimumEtagBeforeReplace, replaceTimeUtc);
+        }
+
+        public Task SideBySideExecuteIndexesAsync(List<AbstractIndexCreationTask> indexCreationTasks, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
+        {
+            return _docStore.SideBySideExecuteIndexesAsync(indexCreationTasks, minimumEtagBeforeReplace, replaceTimeUtc);
+        }
+
         public void ExecuteTransformer(AbstractTransformerCreationTask transformerCreationTask)
         {
             _docStore.ExecuteTransformer(transformerCreationTask);
@@ -428,16 +458,6 @@ Total Size: {8:n0}",
         public ISyncAdvancedSessionOperation Advanced
         {
             get { return _lazySession.Value.Advanced; }
-        }
-
-        public void SideBySideExecuteIndex(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
-        {
-            _docStore.SideBySideExecuteIndex(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
-        }
-
-        public Task SideBySideExecuteIndexAsync(AbstractIndexCreationTask indexCreationTask, Etag minimumEtagBeforeReplace = null, DateTime? replaceTimeUtc = null)
-        {
-            return _docStore.SideBySideExecuteIndexAsync(indexCreationTask, minimumEtagBeforeReplace, replaceTimeUtc);
         }
     }
 }

--- a/RavenLinqpadDriver/RavenLinqpadDriver.csproj
+++ b/RavenLinqpadDriver/RavenLinqpadDriver.csproj
@@ -54,10 +54,12 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RavenLinqpadDriver/RavenLinqpadDriver.csproj
+++ b/RavenLinqpadDriver/RavenLinqpadDriver.csproj
@@ -53,13 +53,11 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Abstractions.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.3690\lib\net45\Raven.Client.Lightweight.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\RavenDB.Client.3.0.30000\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -89,7 +87,9 @@
     <Compile Include="ViewModelBase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="RavenLinqpadDriverStrongNameKey.snk" />
   </ItemGroup>
   <ItemGroup>

--- a/RavenLinqpadDriver/RavenLinqpadDriver.csproj
+++ b/RavenLinqpadDriver/RavenLinqpadDriver.csproj
@@ -66,6 +66,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/RavenLinqpadDriver/packages.config
+++ b/RavenLinqpadDriver/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="3.0.3690" targetFramework="net45" />
+  <package id="RavenDB.Client" version="3.0.30000" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I just updated the packages for RavenDB and the interface for IDocumentStore, but then had to change the serialization to use DataContract and DataMember attributes instead of JsonIgnore because of the way the JsonSerializer is now serializing and handling reference loops.